### PR TITLE
fix NPE when args are null (MessageSource getMessage method signature args are @Nullable)

### DIFF
--- a/src/main/java/com/transferwise/icu/ICUAbstractMessageSource.java
+++ b/src/main/java/com/transferwise/icu/ICUAbstractMessageSource.java
@@ -123,7 +123,7 @@ public abstract class ICUAbstractMessageSource extends ICUMessageSourceSupport i
     }
 
     private boolean isNamedArgumentsMapPresent(Object... args) {
-        return args.length == 1 && args[0] instanceof Map;
+        return args != null && args.length == 1 && args[0] instanceof Map;
     }
 
     @Override

--- a/src/test/java/com/transferwise/icu/ICUMessageSourceTest.java
+++ b/src/test/java/com/transferwise/icu/ICUMessageSourceTest.java
@@ -1,9 +1,6 @@
 package com.transferwise.icu;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -12,8 +9,10 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ICUMessageSourceTest {
 
@@ -179,4 +178,12 @@ class ICUMessageSourceTest {
         String msg = messageSource.getMessage("nonexistent.message", args, "default", Locale.ENGLISH);
         assertEquals("default", msg);
     }
+
+    @Test
+    void testNullArguments() {
+        Object[] args = null;
+        String message = messageSource.getMessage("simple", args, "default", Locale.ENGLISH);
+        assertEquals("Refresh inbox", message);
+    }
+
 }


### PR DESCRIPTION
hi,
This PR makes the implementation conform to MessageSource.getMessage signature that allows [null as args](https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/MessageSource.html#getMessage-java.lang.String-java.lang.Object:A-java.lang.String-java.util.Locale-) (`@Nullable Object[] args`).

Background: i stumbled upon this issue with spring-security, that passed `null` as args:
```
Servlet.service() for servlet [dispatcherServlet] in context with path [/technicalaid] threw exceptionjava.lang.NullPointerException: null
	at com.transferwise.icu.ICUAbstractMessageSource.isNamedArgumentsMapPresent(ICUAbstractMessageSource.java:126)
	at com.transferwise.icu.ICUAbstractMessageSource.getMessage(ICUAbstractMessageSource.java:109)
	at org.springframework.context.support.AbstractApplicationContext.getMessage(AbstractApplicationContext.java:1310)
	at org.springframework.context.support.MessageSourceAccessor.getMessage(MessageSourceAccessor.java:87)
	at org.springframework.security.access.vote.AffirmativeBased.decide(AffirmativeBased.java:84)
	at org.springframework.security.access.intercept.AbstractSecurityInterceptor.beforeInvocation(AbstractSecurityInterceptor.java:233)
	at org.springframework.security.web.access.intercept.FilterSecurityInterceptor.invoke(FilterSecurityInterceptor.java:123)
	at org.springframework.security.web.access.intercept.FilterSecurityInterceptor.doFilter(FilterSecurityInterceptor.java:90)
```
I also included test for this specific use-case